### PR TITLE
Implement active config-jdbc

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,2 +1,3 @@
 * xref:index.adoc[Quarkus Config Extensions]
 * xref:consul.adoc[HashiCorp Consul]
+* xref:jdbc.adoc[JDBC Config]

--- a/docs/modules/ROOT/pages/includes/quarkus-jdbc-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-jdbc-config.adoc
@@ -1,0 +1,135 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[[quarkus-jdbc-config_configuration]]link:#quarkus-jdbc-config_configuration[Configuration property]
+
+h|Type
+h|Default
+
+a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.enabled]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.enabled[quarkus.config.source.jdbc.enabled]`
+
+[.description]
+--
+If set to true, the application will attempt to look up the configuration from DB
+--|boolean 
+|`true`
+
+a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.cache]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.cache[quarkus.config.source.jdbc.cache]`
+
+[.description]
+--
+If set to true, the application will cache all looked up the configuration from DB in memory
+If set to false, the application will always get the latest values from the DB
+--|boolean 
+|`true`
+
+
+a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.table]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.table[quarkus.config.source.jdbc.table]`
+
+[.description]
+--
+Table name for configuration records
+--|string 
+|`configuration`
+
+
+a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.key]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.key[quarkus.config.source.jdbc.key]`
+
+[.description]
+--
+Name of the column containing the key
+--|string 
+|`key`
+
+
+a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.value]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.value[quarkus.config.source.jdbc.value]`
+
+[.description]
+--
+Name of the column containing the value
+--|string 
+|`value`
+
+
+a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.username]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.username[quarkus.config.source.jdbc.username]`
+
+[.description]
+--
+The datasource username, if not defined the usename of the default datasource is used
+--|string 
+| value of `quarkus.datasource.username`
+
+
+a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.password]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.password[quarkus.config.source.jdbc.password]`
+
+[.description]
+--
+The datasource password, if not defined the password of the default datasource is used
+--|string 
+| value of `quarkus.datasource.password`
+
+
+a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.url]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.url[quarkus.config.source.jdbc.url]`
+
+[.description]
+--
+The datasource URL, if not defined the URL of the default datasource is used
+--|string 
+| value of `quarkus.datasource..jdbc.url`
+
+
+a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.initial-size]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.initial-size[quarkus.config.source.jdbc.initial-size]`
+
+[.description]
+--
+The initial size of the pool. Usually you will want to set the initial size to match at least the minimal size, but this is not enforced so to allow for architectures which prefer a lazy initialization of the connections on boot, while being able to sustain a minimal pool size after boot.
+--|int 
+|`0`
+
+
+a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.min-size]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.min-size[quarkus.config.source.jdbc.min-size]`
+
+[.description]
+--
+The int pool minimum size
+--|int 
+|`0`
+
+
+a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.max-size]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.max-size[quarkus.config.source.jdbc.max-size]`
+
+[.description]
+--
+The datasource pool maximum size
+--|int 
+|`5`
+
+
+a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.acquisition-timeout]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.acquisition-timeout[quarkus.config.source.jdbc.acquisition-timeout]`
+
+[.description]
+--
+The timeout before cancelling the acquisition of a new connection
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|`5`
+
+
+
+
+|===
+ifndef::no-duration-note[]
+[NOTE]
+[[duration-note-anchor]]
+.About the Duration format
+====
+The format for durations uses the standard `java.time.Duration` format.
+You can learn more about it in the link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-[Duration#parse() javadoc].
+
+You can also provide duration values starting with a number.
+In this case, if the value consists only of a number, the converter treats the value as seconds.
+Otherwise, `PT` is implicitly prepended to the value to obtain a standard `java.time.Duration` format.
+====
+endif::no-duration-note[]

--- a/docs/modules/ROOT/pages/jdbc.adoc
+++ b/docs/modules/ROOT/pages/jdbc.adoc
@@ -1,0 +1,142 @@
+= Quarkus JDBC Config
+
+include::./includes/attributes.adoc[]
+
+This guide explains how your Quarkus application can read configuration properties from a database using JDBC
+
+== Prerequisites
+
+To complete this guide, you need:
+
+* less than 15 minutes
+* an IDE
+* JDK 11+ installed with `JAVA_HOME` configured appropriately
+* Apache Maven {maven-version}
+
+
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+
+== Introduction
+
+A database table can be used as a Key-Value store as a source of configuration for services.
+This table is what the `quarkus-config-jsbc` extension interacts with in order to allow Quarkus applications to read configuration properties from.
+
+== Creating the Maven project
+
+First, we need a new project. Create a new project with the following command:
+
+[source,bash,subs=attributes+]
+----
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
+    -DprojectGroupId=org.acme \
+    -DprojectArtifactId=config-jdbc-quickstart \
+    -DclassName="org.acme.jdbc.config.GreetingResource" \
+    -Dpath="/greeting" \
+    -Dextensions="config-jdbc"
+cd config-jdbc-quickstart
+----
+
+This command generates a Maven project with a REST endpoint and imports the `config-jdbc` extension.
+
+If you already have your Quarkus project configured, you can add the `config-jdbc` extension
+to your project by running the following command in your project base directory:
+
+[source,bash]
+----
+./mvnw quarkus:add-extension -Dextensions="config-jdbc"
+----
+
+This will add the following to your `pom.xml`:
+
+[source,xml,subs=attributes+]
+----
+<dependency>
+    <groupId>io.quarkiverse.config</groupId>
+    <artifactId>quarkus-config-jdbc</artifactId>
+    <version>{quarkus-config-extensions-version}</version>
+</dependency>
+----
+
+== GreetingController
+
+The Quarkus Maven plugin automatically generated a `GreetingResource` JAX-RS resource in the
+`src/main/java/org/acme/consul/config/client/GreetingResource.java` file that looks like:
+
+[source,java]
+----
+package org.acme.consul.config.client;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+@Path("/greeting")
+public class GreetingResource {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+}
+----
+
+As we want to use configuration properties obtained from the Config Server, we will update the `GreetingResource` to inject the `message` property. The updated code will look like this:
+
+[source,java]
+----
+package org.acme.consul.config.client;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+@Path("/greeting")
+public class GreetingResource {
+    @ConfigProperty(name = "greeting.message", defaultValue="Hello from default")
+    String message;
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return message;
+    }
+}
+----
+
+== Configuring the application
+
+Quarkus provides various configuration knobs under the `quarkus.config.source.jdbc` root. For the purposes of this guide, our Quarkus application is going to be configured in `application.properties` as follows:
+
+[source,properties]
+----
+quarkus.config.source.jdbc.username=sa
+quarkus.config.source.jdbc.password=sa
+quarkus.config.source.jdbc.url=jdbc:h2:tcp://localhost/mem:test
+----
+
+== Add Configuration to Database
+
+For the previous application configuration to work, we need to have a table named `configuration` with two columns `key` and `value` with a record inserted into it
+
+[source,properties]
+----
+CREATE TABLE IF NOT EXISTS configuration (key varchar(255), value varchar(255));
+
+INSERT INTO configuration (key, value)
+VALUES ('greeting.message', 'Hello from DB');
+----
+
+== Package and run the application
+
+Run the application with: `./mvnw compile quarkus:dev`.
+Open your browser to http://localhost:8080/greeting.
+
+The result should be: `Hello from DB` as it is the value obtained from the Consul Key Value store.
+
+== Run the application as a native executable
+
+You can of course create a native image using the instructions of the link:building-native-image[Building a native executable guide].
+
+== Configuration Reference
+
+include::./includes/quarkus-jdbc-config.adoc[]

--- a/docs/modules/ROOT/pages/jdbc.adoc
+++ b/docs/modules/ROOT/pages/jdbc.adoc
@@ -131,7 +131,7 @@ VALUES ('greeting.message', 'Hello from DB');
 Run the application with: `./mvnw compile quarkus:dev`.
 Open your browser to http://localhost:8080/greeting.
 
-The result should be: `Hello from DB` as it is the value obtained from the Consul Key Value store.
+The result should be: `Hello from DB` as it is the value obtained from the database.
 
 == Run the application as a native executable
 

--- a/jdbc/deployment/src/test/java/io/quarkiverse/config/jdbc/extensions/test/JdbcConfigCustomParamsTest.java
+++ b/jdbc/deployment/src/test/java/io/quarkiverse/config/jdbc/extensions/test/JdbcConfigCustomParamsTest.java
@@ -18,13 +18,13 @@ public class JdbcConfigCustomParamsTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
-            .create(JavaArchive.class).addAsResource("default_application.properties", "application.properties"));
+            .create(JavaArchive.class).addAsResource("custom_application.properties", "application.properties"));
 
     @Test
-    @DisplayName("Reads a property from custom config DB")
+    @DisplayName("Reads a property from config DB")
     public void readGreetingFromDB() {
         Config c = ConfigProvider.getConfig();
         String message = c.getValue("greeting.message", String.class);
-        Assertions.assertEquals("hello from default table", message);
+        Assertions.assertEquals("hello from custom table", message);
     }
 }

--- a/jdbc/deployment/src/test/java/io/quarkiverse/config/jdbc/extensions/test/JdbcConfigCustomParamsTest.java
+++ b/jdbc/deployment/src/test/java/io/quarkiverse/config/jdbc/extensions/test/JdbcConfigCustomParamsTest.java
@@ -38,6 +38,7 @@ public class JdbcConfigCustomParamsTest {
 
         int result = updateConfigValue("greeting.message", "updated hello from custom table");
         Assertions.assertTrue(result > 0);
+        // assert we are getting the updated message because cache is disabled
         message = c.getValue("greeting.message", String.class);
         Assertions.assertEquals("updated hello from custom table", message);
     }

--- a/jdbc/deployment/src/test/java/io/quarkiverse/config/jdbc/extensions/test/JdbcConfigCustomParamsTest.java
+++ b/jdbc/deployment/src/test/java/io/quarkiverse/config/jdbc/extensions/test/JdbcConfigCustomParamsTest.java
@@ -1,5 +1,11 @@
 package io.quarkiverse.config.jdbc.extensions.test;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import javax.inject.Inject;
+import javax.sql.DataSource;
+
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -20,11 +26,27 @@ public class JdbcConfigCustomParamsTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
             .create(JavaArchive.class).addAsResource("custom_application.properties", "application.properties"));
 
+    @Inject
+    DataSource dataSource;
+
     @Test
     @DisplayName("Reads a property from config DB")
-    public void readGreetingFromDB() {
+    public void readGreetingFromDB() throws SQLException {
         Config c = ConfigProvider.getConfig();
         String message = c.getValue("greeting.message", String.class);
         Assertions.assertEquals("hello from custom table", message);
+
+        int result = updateConfigValue("greeting.message", "updated hello from custom table");
+        Assertions.assertTrue(result > 0);
+        message = c.getValue("greeting.message", String.class);
+        Assertions.assertEquals("updated hello from custom table", message);
+    }
+
+    private int updateConfigValue(String key, String value) throws SQLException {
+        PreparedStatement updateStatement = dataSource.getConnection()
+                .prepareStatement("UPDATE custom_config c SET c.b = ? WHERE c.a = ?");
+        updateStatement.setString(1, value);
+        updateStatement.setString(2, key);
+        return updateStatement.executeUpdate();
     }
 }

--- a/jdbc/deployment/src/test/java/io/quarkiverse/config/jdbc/extensions/test/JdbcConfigDefaultParamsTest.java
+++ b/jdbc/deployment/src/test/java/io/quarkiverse/config/jdbc/extensions/test/JdbcConfigDefaultParamsTest.java
@@ -18,13 +18,13 @@ public class JdbcConfigDefaultParamsTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
-            .create(JavaArchive.class).addAsResource("custom_application.properties", "application.properties"));
+            .create(JavaArchive.class).addAsResource("default_application.properties", "application.properties"));
 
     @Test
-    @DisplayName("Reads a property from config DB")
+    @DisplayName("Reads a property from custom config DB")
     public void readGreetingFromDB() {
         Config c = ConfigProvider.getConfig();
         String message = c.getValue("greeting.message", String.class);
-        Assertions.assertEquals("hello from custom table", message);
+        Assertions.assertEquals("hello from default table", message);
     }
 }

--- a/jdbc/deployment/src/test/java/io/quarkiverse/config/jdbc/extensions/test/JdbcConfigDefaultParamsTest.java
+++ b/jdbc/deployment/src/test/java/io/quarkiverse/config/jdbc/extensions/test/JdbcConfigDefaultParamsTest.java
@@ -38,6 +38,7 @@ public class JdbcConfigDefaultParamsTest {
 
         int result = updateConfigValue("greeting.message", "updated hello from default table");
         Assertions.assertTrue(result > 0);
+        // assert we are still getting the original message because cache is enabled
         message = c.getValue("greeting.message", String.class);
         Assertions.assertEquals("hello from default table", message);
     }

--- a/jdbc/deployment/src/test/java/io/quarkiverse/config/jdbc/extensions/test/JdbcConfigDefaultParamsTest.java
+++ b/jdbc/deployment/src/test/java/io/quarkiverse/config/jdbc/extensions/test/JdbcConfigDefaultParamsTest.java
@@ -1,5 +1,11 @@
 package io.quarkiverse.config.jdbc.extensions.test;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import javax.inject.Inject;
+import javax.sql.DataSource;
+
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -20,11 +26,27 @@ public class JdbcConfigDefaultParamsTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
             .create(JavaArchive.class).addAsResource("default_application.properties", "application.properties"));
 
+    @Inject
+    DataSource dataSource;
+
     @Test
     @DisplayName("Reads a property from custom config DB")
-    public void readGreetingFromDB() {
+    public void readGreetingFromDB() throws SQLException {
         Config c = ConfigProvider.getConfig();
         String message = c.getValue("greeting.message", String.class);
         Assertions.assertEquals("hello from default table", message);
+
+        int result = updateConfigValue("greeting.message", "updated hello from default table");
+        Assertions.assertTrue(result > 0);
+        message = c.getValue("greeting.message", String.class);
+        Assertions.assertEquals("hello from default table", message);
+    }
+
+    private int updateConfigValue(String key, String value) throws SQLException {
+        PreparedStatement updateStatement = dataSource.getConnection()
+                .prepareStatement("UPDATE configuration c SET c.value = ? WHERE c.key = ?");
+        updateStatement.setString(1, value);
+        updateStatement.setString(2, key);
+        return updateStatement.executeUpdate();
     }
 }

--- a/jdbc/deployment/src/test/resources/custom_application.properties
+++ b/jdbc/deployment/src/test/resources/custom_application.properties
@@ -2,7 +2,15 @@
 %test.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'src/test/resources/custom_import.sql'
 %test.quarkus.datasource.username=sa
 %test.quarkus.datasource.password=sa
+# config-jdbc
 %test.quarkus.config.source.jdbc.table=custom_config
 %test.quarkus.config.source.jdbc.key=a
 %test.quarkus.config.source.jdbc.value=b
 %test.quarkus.config.source.jdbc.cache=false
+%test.quarkus.config.source.jdbc.username=sa
+%test.quarkus.config.source.jdbc.password=sa
+%test.quarkus.config.source.jdbc.url=jdbc:h2:tcp://localhost/mem:test;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'src/test/resources/custom_import.sql'
+%test.quarkus.config.source.jdbc.initial-size=3
+%test.quarkus.config.source.jdbc.min-size=3
+%test.quarkus.config.source.jdbc.max-size=5
+%test.quarkus.config.source.jdbc.acquisition-timeout=5

--- a/jdbc/deployment/src/test/resources/custom_application.properties
+++ b/jdbc/deployment/src/test/resources/custom_application.properties
@@ -5,3 +5,4 @@
 %test.quarkus.config.source.jdbc.table=custom_config
 %test.quarkus.config.source.jdbc.key=a
 %test.quarkus.config.source.jdbc.value=b
+%test.quarkus.config.source.jdbc.cache=false

--- a/jdbc/deployment/src/test/resources/default_application.properties
+++ b/jdbc/deployment/src/test/resources/default_application.properties
@@ -3,4 +3,3 @@
 %test.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'src/test/resources/default_import.sql'
 %test.quarkus.datasource.username=sa
 %test.quarkus.datasource.password=sa
-#%test.quarkus.config.source.jdbc.enabled=false

--- a/jdbc/deployment/src/test/resources/default_application.properties
+++ b/jdbc/deployment/src/test/resources/default_application.properties
@@ -1,5 +1,4 @@
 %test.quarkus.datasource.db-kind=h2
-#quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'src/test/resources/default_import.sql'
 %test.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'src/test/resources/default_import.sql'
 %test.quarkus.datasource.username=sa
 %test.quarkus.datasource.password=sa

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigConfig.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigConfig.java
@@ -33,36 +33,36 @@ public class JdbcConfigConfig {
      * Table name for configuration records
      */
     @ConfigItem(name = "table", defaultValue = "configuration")
-    public Optional<String> table = Optional.of("configuration");
+    public String table;
 
     /**
      * Name of the column containing the key
      */
     @ConfigItem(name = "key", defaultValue = "key")
-    public Optional<String> keyColumn = Optional.of("key");
+    public String keyColumn;
 
     /**
      * Name of the column containing the value
      */
     @ConfigItem(name = "value", defaultValue = "value")
-    public Optional<String> valueColumn = Optional.of("value");
+    public String valueColumn;
 
     /**
      * The datasource username, if not defined the usename of the default datasource is used
      */
-    @ConfigItem
+    @ConfigItem(name = "username")
     public Optional<String> username = Optional.empty();;
 
     /**
      * The datasource password, if not defined the password of the default datasource is used
      */
-    @ConfigItem
+    @ConfigItem(name = "password")
     public Optional<String> password = Optional.empty();;
 
     /**
      * The datasource URL, if not defined the URL of the default datasource is used
      */
-    @ConfigItem
+    @ConfigItem(name = "url")
     public Optional<String> url = Optional.empty();
 
     /**
@@ -70,24 +70,24 @@ public class JdbcConfigConfig {
      * minimal size, but this is not enforced so to allow for architectures which prefer a lazy initialization
      * of the connections on boot, while being able to sustain a minimal pool size after boot.
      */
-    @ConfigItem(defaultValue = "0")
+    @ConfigItem(name = "initial-size", defaultValue = "0")
     public int initialSize = 0;
 
     /**
      * The datasource pool minimum size
      */
-    @ConfigItem(defaultValue = "0")
+    @ConfigItem(name = "min-size", defaultValue = "0")
     public int minSize = 0;
 
     /**
      * The datasource pool maximum size
      */
-    @ConfigItem(defaultValue = "5")
+    @ConfigItem(name = "max-size", defaultValue = "5")
     public int maxSize = 5;
 
     /**
      * The timeout before cancelling the acquisition of a new connection
      */
-    @ConfigItem(defaultValue = "5")
+    @ConfigItem(name = "acquisition-timeout", defaultValue = "5")
     public Duration acquisitionTimeout = Duration.ofSeconds(5);
 }

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigConfig.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigConfig.java
@@ -38,4 +38,11 @@ public class JdbcConfigConfig {
      */
     @ConfigItem(name = "value", defaultValue = "value")
     public Optional<String> valueColumn;
+
+    /**
+     * If set to true, the application will cache all looked up the configuration from DB in memory
+     * If set to false, the application will always get the latest values from the DB
+     */
+    @ConfigItem(name = "cache", defaultValue = "true")
+    public boolean cache;
 }

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigConfig.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigConfig.java
@@ -48,7 +48,7 @@ public class JdbcConfigConfig {
     public String valueColumn;
 
     /**
-     * The datasource username, if not defined the usename of the default datasource is used
+     * The datasource username, if not defined the username of the default datasource is used
      */
     @ConfigItem(name = "username")
     public Optional<String> username = Optional.empty();;

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigConfig.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigConfig.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.config.jdbc.runtime;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -19,30 +20,74 @@ public class JdbcConfigConfig {
      * If set to true, the application will attempt to look up the configuration from DB
      */
     @ConfigItem(name = "enabled", defaultValue = "true")
-    public boolean enabled;
-
-    /**
-     * Table name for configuration records
-     */
-    @ConfigItem(name = "table", defaultValue = "configuration")
-    public Optional<String> table;
-
-    /**
-     * Name of the column containing the key
-     */
-    @ConfigItem(name = "key", defaultValue = "key")
-    public Optional<String> keyColumn;
-
-    /**
-     * name of the column containing the value
-     */
-    @ConfigItem(name = "value", defaultValue = "value")
-    public Optional<String> valueColumn;
+    public boolean enabled = true;
 
     /**
      * If set to true, the application will cache all looked up the configuration from DB in memory
      * If set to false, the application will always get the latest values from the DB
      */
     @ConfigItem(name = "cache", defaultValue = "true")
-    public boolean cache;
+    public boolean cache = true;
+
+    /**
+     * Table name for configuration records
+     */
+    @ConfigItem(name = "table", defaultValue = "configuration")
+    public Optional<String> table = Optional.of("configuration");
+
+    /**
+     * Name of the column containing the key
+     */
+    @ConfigItem(name = "key", defaultValue = "key")
+    public Optional<String> keyColumn = Optional.of("key");
+
+    /**
+     * Name of the column containing the value
+     */
+    @ConfigItem(name = "value", defaultValue = "value")
+    public Optional<String> valueColumn = Optional.of("value");
+
+    /**
+     * The datasource username, if not defined the usename of the default datasource is used
+     */
+    @ConfigItem
+    public Optional<String> username = Optional.empty();;
+
+    /**
+     * The datasource password, if not defined the password of the default datasource is used
+     */
+    @ConfigItem
+    public Optional<String> password = Optional.empty();;
+
+    /**
+     * The datasource URL, if not defined the URL of the default datasource is used
+     */
+    @ConfigItem
+    public Optional<String> url = Optional.empty();
+
+    /**
+     * The initial size of the pool. Usually you will want to set the initial size to match at least the
+     * minimal size, but this is not enforced so to allow for architectures which prefer a lazy initialization
+     * of the connections on boot, while being able to sustain a minimal pool size after boot.
+     */
+    @ConfigItem(defaultValue = "0")
+    public int initialSize = 0;
+
+    /**
+     * The datasource pool minimum size
+     */
+    @ConfigItem(defaultValue = "0")
+    public int minSize = 0;
+
+    /**
+     * The datasource pool maximum size
+     */
+    @ConfigItem(defaultValue = "5")
+    public int maxSize = 5;
+
+    /**
+     * The timeout before cancelling the acquisition of a new connection
+     */
+    @ConfigItem(defaultValue = "5")
+    public Duration acquisitionTimeout = Duration.ofSeconds(5);
 }

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSource.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSource.java
@@ -1,6 +1,5 @@
 package io.quarkiverse.config.jdbc.runtime;
 
-import java.sql.SQLException;
 import java.util.Map;
 import java.util.Set;
 
@@ -19,31 +18,17 @@ public class JdbcConfigSource extends AbstractConfigSource {
 
     @Override
     public Map<String, String> getProperties() {
-        try {
-            return repository.getAllConfigValues();
-        } catch (SQLException e) {
-            log.warn("jdbc-config unable to get properties: " + e.getLocalizedMessage());
-            return Map.of();
-        }
+        return repository.getAllConfigValues();
     }
 
     @Override
     public Set<String> getPropertyNames() {
-        try {
-            return repository.getPropertyNames();
-        } catch (SQLException e) {
-            log.warn("jdbc-config unable to get property names: " + e.getLocalizedMessage());
-            return Set.of();
-        }
+        return repository.getPropertyNames();
     }
 
     @Override
     public String getValue(String propertyName) {
-        try {
-            return repository.getValue(propertyName);
-        } catch (SQLException e) {
-            return null;
-        }
+        return repository.getValue(propertyName);
     }
 
 }

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSource.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSource.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.config.jdbc.runtime;
+
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Set;
+
+import io.smallrye.config.common.AbstractConfigSource;
+
+public class JdbcConfigSource extends AbstractConfigSource {
+
+    private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(JdbcConfigSource.class);
+
+    private final Repository repository;
+
+    public JdbcConfigSource(String name, Repository repository, int defaultOrdinal) {
+        super(name, defaultOrdinal);
+        this.repository = repository;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        try {
+            return repository.getAllConfigValues();
+        } catch (SQLException e) {
+            log.warn("jdbc-config unable to get properties: " + e.getLocalizedMessage());
+            return Map.of();
+        }
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        try {
+            return repository.getPropertyNames();
+        } catch (SQLException e) {
+            log.warn("jdbc-config unable to get property names: " + e.getLocalizedMessage());
+            return Set.of();
+        }
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        try {
+            return repository.getValue(propertyName);
+        } catch (SQLException e) {
+            return null;
+        }
+    }
+
+}

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSource.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSource.java
@@ -7,8 +7,6 @@ import io.smallrye.config.common.AbstractConfigSource;
 
 public class JdbcConfigSource extends AbstractConfigSource {
 
-    private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(JdbcConfigSource.class);
-
     private final Repository repository;
 
     public JdbcConfigSource(String name, Repository repository, int defaultOrdinal) {

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSource.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSource.java
@@ -6,7 +6,6 @@ import java.util.Set;
 import io.smallrye.config.common.AbstractConfigSource;
 
 public class JdbcConfigSource extends AbstractConfigSource {
-
     private final Repository repository;
 
     public JdbcConfigSource(String name, Repository repository, int defaultOrdinal) {
@@ -28,5 +27,4 @@ public class JdbcConfigSource extends AbstractConfigSource {
     public String getValue(String propertyName) {
         return repository.getValue(propertyName);
     }
-
 }

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSourceFactory.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSourceFactory.java
@@ -32,7 +32,6 @@ public class JdbcConfigSourceFactory implements ConfigSourceFactory {
     }
 
     protected List<ConfigSource> getConfigSource(final JdbcConfigConfig config, final Repository repository) {
-
         if (!config.enabled) {
             return Collections.emptyList();
         }
@@ -47,23 +46,22 @@ public class JdbcConfigSourceFactory implements ConfigSourceFactory {
         }
 
         return list;
-
     }
 
     private JdbcConfigConfig populateConfig(ConfigSourceContext context) {
         final JdbcConfigConfig config = new JdbcConfigConfig();
 
         // jdbc-config parameters
-
-        config.enabled = Boolean.valueOf(Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.enabled").getValue())
-                .orElse(String.valueOf(config.enabled)));
+        config.enabled = Boolean
+                .parseBoolean(Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.enabled").getValue())
+                        .orElse(String.valueOf(config.enabled)));
 
         // short-circuit if config is disabled
         if (!config.enabled) {
             return config;
         }
 
-        config.cache = Boolean.valueOf(Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.cache").getValue())
+        config.cache = Boolean.parseBoolean(Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.cache").getValue())
                 .orElse(String.valueOf(config.cache)));
 
         // table, keyColumn, valueColumn
@@ -98,7 +96,7 @@ public class JdbcConfigSourceFactory implements ConfigSourceFactory {
         Optional<String> timeout = Optional
                 .ofNullable(context.getValue("quarkus.config.source.jdbc.acquisition-timeout").getValue());
 
-        // acquisitionTimeout (java.time.Duration) is allowed to be just numbers (seconds) or standart Duratino format (PTXX)
+        // acquisitionTimeout (java.time.Duration) is allowed to be just numbers (seconds) or standard Duration format (PTXX)
         if (timeout.isPresent() && timeout.get().matches("[0-9]+")) {
             config.acquisitionTimeout = Duration.ofSeconds(Long.parseLong(timeout.get()));
         } else {
@@ -108,11 +106,8 @@ public class JdbcConfigSourceFactory implements ConfigSourceFactory {
     }
 
     private static final class InMemoryConfigSource extends MapBackedConfigSource {
-
         public InMemoryConfigSource(String name, Map<String, String> propertyMap, int defaultOrdinal) {
             super(name, propertyMap, defaultOrdinal);
         }
-
     }
-
 }

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSourceFactory.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSourceFactory.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.config.jdbc.runtime;
 
 import java.sql.SQLException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -15,46 +16,32 @@ import io.smallrye.config.ConfigSourceFactory;
 import io.smallrye.config.common.MapBackedConfigSource;
 
 public class JdbcConfigSourceFactory implements ConfigSourceFactory {
+
     private static final Logger log = Logger.getLogger(JdbcConfigSourceFactory.class);
     Repository repository = null;
+    JdbcConfigConfig config;
 
     @Override
     public Iterable<ConfigSource> getConfigSources(ConfigSourceContext context) {
-        return getConfigSource(context);
+        populateConfig(context);
+        return getConfigSource();
     }
 
-    private List<ConfigSource> getConfigSource(ConfigSourceContext context) {
+    private List<ConfigSource> getConfigSource() {
 
-        boolean enabled = Boolean.valueOf(
-                Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.enabled").getValue()).orElse("true"));
-        if (!enabled) {
+        if (!config.enabled) {
             return Collections.emptyList();
         }
-
-        String table = Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.table").getValue())
-                .orElse("configuration");
-        String keyColumn = Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.key").getValue())
-                .orElse("key");
-        String valueColumn = Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.value").getValue())
-                .orElse("value");
-        boolean cacheEnabled = Boolean
-                .valueOf(Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.cache").getValue())
-                        .orElse("true"));
-
-        // Datasource config
-        String username = context.getValue("quarkus.datasource.username").getValue();
-        String password = context.getValue("quarkus.datasource.password").getValue();
-        String url = context.getValue("quarkus.datasource.jdbc.url").getValue();
 
         Map<String, String> result;
         List<ConfigSource> list = new ArrayList<>();
         if (repository == null) {
-            repository = new Repository(url, username, password, table, keyColumn, valueColumn);
+            repository = new Repository(config);
         }
         try {
             result = repository.getAllConfigValues();
 
-            if (cacheEnabled) {
+            if (config.cache) {
                 list.add(new InMemoryConfigSource("jdbc-config", result, 400));
             } else {
                 list.add(new JdbcConfigSource("jdbc-config", repository, 400));
@@ -66,6 +53,62 @@ public class JdbcConfigSourceFactory implements ConfigSourceFactory {
         }
         return list;
 
+    }
+
+    private void populateConfig(ConfigSourceContext context) {
+        config = new JdbcConfigConfig();
+
+        // jdbc-config parameters
+
+        config.enabled = Boolean.valueOf(Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.enabled").getValue())
+                .orElse(String.valueOf(config.enabled)));
+
+        // short-circuit if config is disabled
+        if (!config.enabled) {
+            return;
+        }
+
+        config.cache = Boolean.valueOf(Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.cache").getValue())
+                .orElse(String.valueOf(config.cache)));
+
+        // table, keyColumn, valueColumn
+        config.table = Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.table").getValue())
+                .or(() -> config.table);
+        config.keyColumn = Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.key").getValue())
+                .or(() -> config.keyColumn);
+        config.valueColumn = Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.value").getValue())
+                .or(() -> config.valueColumn);
+
+        // connection parameters
+
+        // url, username, password (use default datasource values if jdbc-config values are not defined )
+        config.username = Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.username").getValue())
+                .or(() -> Optional.ofNullable(context.getValue("quarkus.datasource.username").getValue()));
+        config.password = Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.password").getValue())
+                .or(() -> Optional.ofNullable(context.getValue("quarkus.datasource.password").getValue()));
+        config.url = Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.url").getValue())
+                .or(() -> Optional.ofNullable(context.getValue("quarkus.datasource.jdbc.url").getValue()));
+
+        // initialSize, minSize, maxSize, acquisitionTimeout
+        config.initialSize = Integer
+                .parseInt(Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.initial-size").getValue())
+                        .orElse(String.valueOf(config.initialSize)));
+        config.minSize = Integer
+                .parseInt(Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.min-size").getValue())
+                        .orElse(String.valueOf(config.minSize)));
+        config.maxSize = Integer
+                .parseInt(Optional.ofNullable(context.getValue("quarkus.config.source.jdbc.max-size").getValue())
+                        .orElse(String.valueOf(config.maxSize)));
+
+        Optional<String> timeout = Optional
+                .ofNullable(context.getValue("quarkus.config.source.jdbc.acquisition-timeout").getValue());
+
+        // acquisitionTimeout (java.time.Duration) is allowed to be just numbers (seconds) or standart Duratino format (PTXX)
+        if (timeout.isPresent() && timeout.get().matches("[0-9]+")) {
+            config.acquisitionTimeout = Duration.ofSeconds(Long.parseLong(timeout.get()));
+        } else {
+            config.acquisitionTimeout = Duration.parse(timeout.orElse(config.acquisitionTimeout.toString()));
+        }
     }
 
     private static final class InMemoryConfigSource extends MapBackedConfigSource {

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSourceFactory.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSourceFactory.java
@@ -48,10 +48,10 @@ public class JdbcConfigSourceFactory implements ConfigSourceFactory {
 
         Map<String, String> result;
         List<ConfigSource> list = new ArrayList<>();
+        if (repository == null) {
+            repository = new Repository(url, username, password, table, keyColumn, valueColumn);
+        }
         try {
-            if (repository == null) {
-                repository = new Repository(url, username, password, table, keyColumn, valueColumn);
-            }
             result = repository.getAllConfigValues();
 
             if (cacheEnabled) {

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSourceFactory.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSourceFactory.java
@@ -33,13 +33,12 @@ public class JdbcConfigSourceFactory implements ConfigSourceFactory {
             return Collections.emptyList();
         }
 
-        Map<String, String> result;
-        List<ConfigSource> list = new ArrayList<>();
-        if (repository == null) {
-            repository = new Repository(config);
-        }
+        final List<ConfigSource> list = new ArrayList<>();
         try {
-            result = repository.getAllConfigValues();
+            if (repository == null) {
+                repository = new Repository(config);
+            }
+            final Map<String, String> result = repository.getAllConfigValues();
 
             if (config.cache) {
                 list.add(new InMemoryConfigSource("jdbc-config", result, 400));

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/Repository.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/Repository.java
@@ -32,7 +32,7 @@ public class Repository implements AutoCloseable {
         prepareDataSource();
     }
 
-    public synchronized Map<String, String> getAllConfigValues() throws SQLException {
+    public synchronized Map<String, String> getAllConfigValues() {
         final String selectAllQuery = new StringBuilder("SELECT conf.").append(config.keyColumn.get())
                 .append(", conf.").append(config.valueColumn.get())
                 .append(" FROM ").append(config.table.get()).append(" conf").toString();
@@ -52,7 +52,7 @@ public class Repository implements AutoCloseable {
         }
     }
 
-    public synchronized Set<String> getPropertyNames() throws SQLException {
+    public synchronized Set<String> getPropertyNames() {
         final String selectKeysQuery = new StringBuilder("SELECT conf.").append(config.keyColumn.get())
                 .append(" FROM ").append(config.table.get()).append(" conf").toString();
 
@@ -71,7 +71,7 @@ public class Repository implements AutoCloseable {
         }
     }
 
-    public String getValue(String propertyName) throws SQLException {
+    public String getValue(String propertyName) {
         final String selectValueQuery = new StringBuilder("SELECT conf.").append(config.valueColumn.get())
                 .append(" FROM ").append(config.table.get()).append(" conf")
                 .append(" WHERE conf.").append(config.keyColumn.get()).append(" = ?").toString();

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/Repository.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/Repository.java
@@ -31,8 +31,7 @@ public class Repository implements AutoCloseable {
     private PreparedStatement selectKeys;
     private PreparedStatement selectValue;
 
-    public Repository(String url, String username, String password, String table, String keyColumn, String valueColumn)
-            throws SQLException {
+    public Repository(String url, String username, String password, String table, String keyColumn, String valueColumn) {
         this.url = url;
         this.username = username;
         this.password = password;

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/Repository.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/Repository.java
@@ -45,6 +45,8 @@ public class Repository implements AutoCloseable {
                     result.put(rs.getString(1), rs.getString(2));
                 }
                 return result;
+            } finally {
+                selectAllStmt.close();
             }
         } catch (SQLException e) {
             log.trace("config-jdbc: could not get values: " + e.getLocalizedMessage());
@@ -61,6 +63,8 @@ public class Repository implements AutoCloseable {
                     keys.add(rs.getString(1));
                 }
                 return keys;
+            } finally {
+                selectKeysStmt.close();
             }
         } catch (SQLException e) {
             log.trace("config-jdbc: could not get keys: " + e.getLocalizedMessage());
@@ -76,6 +80,8 @@ public class Repository implements AutoCloseable {
                 while (rs.next()) {
                     return rs.getString(1);
                 }
+            } finally {
+                selectValueStmt.close();
             }
         } catch (SQLException e) {
             log.trace("config-jdbc: could not get value for key " + propertyName + ": " + e.getLocalizedMessage());

--- a/jdbc/runtime/src/test/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSourceFactoryTest.java
+++ b/jdbc/runtime/src/test/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSourceFactoryTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import io.agroal.api.AgroalDataSource;
 import io.smallrye.config.ConfigSourceContext;
 import io.smallrye.config.ConfigValue;
 
@@ -22,6 +23,7 @@ public class JdbcConfigSourceFactoryTest {
     private ConfigSourceContext context = mock(ConfigSourceContext.class);
     private Repository repository = mock(Repository.class);
     private ConfigValue config = mock(ConfigValue.class);
+    private AgroalDataSource dataSource = mock(AgroalDataSource.class);
 
     @Test
     @DisplayName("Repository returns data")
@@ -47,22 +49,6 @@ public class JdbcConfigSourceFactoryTest {
 
         assertEquals(value, configSource.getValue(key));
 
-    }
-
-    @Test
-    @DisplayName("On SQLException datasource is empty")
-    void testOnSqlException() throws SQLException {
-        JdbcConfigSourceFactory factory = new JdbcConfigSourceFactory();
-
-        when(context.getValue(Mockito.anyString())).thenReturn(config);
-        when(config.getValue()).thenReturn(null);
-        when(repository.getAllConfigValues())
-                .thenThrow(new SQLException());
-
-        factory.repository = repository;
-        Iterable<ConfigSource> it = factory.getConfigSources(context);
-
-        assertTrue(((Collection<?>) it).isEmpty());
     }
 
     @Test

--- a/jdbc/runtime/src/test/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSourceFactoryTest.java
+++ b/jdbc/runtime/src/test/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSourceFactoryTest.java
@@ -26,14 +26,17 @@ public class JdbcConfigSourceFactoryTest {
     @Test
     @DisplayName("Repository returns data")
     void testOnStoredData() throws SQLException {
+        String key = "foo";
+        String value = "sample value";
         JdbcConfigSourceFactory factory = new JdbcConfigSourceFactory();
         Map<String, String> map = new HashMap<>();
-        map.put("foo", "sample value");
+        map.put(key, value);
 
         when(context.getValue(Mockito.anyString())).thenReturn(config);
         when(config.getValue()).thenReturn(null);
-        when(repository.getAllConfigValues(Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(map);
+
+        when(repository.getAllConfigValues()).thenReturn(map);
+        when(repository.getValue(key)).thenReturn(value);
 
         factory.repository = repository;
         Iterable<ConfigSource> it = factory.getConfigSources(context);
@@ -42,7 +45,7 @@ public class JdbcConfigSourceFactoryTest {
 
         ConfigSource configSource = it.iterator().next();
 
-        assertEquals("sample value", configSource.getValue("foo"));
+        assertEquals(value, configSource.getValue(key));
 
     }
 
@@ -53,13 +56,13 @@ public class JdbcConfigSourceFactoryTest {
 
         when(context.getValue(Mockito.anyString())).thenReturn(config);
         when(config.getValue()).thenReturn(null);
-        when(repository.getAllConfigValues(Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+        when(repository.getAllConfigValues())
                 .thenThrow(new SQLException());
 
         factory.repository = repository;
         Iterable<ConfigSource> it = factory.getConfigSources(context);
 
-        assertTrue(((Collection<?>) it).size() == 0);
+        assertTrue(((Collection<?>) it).isEmpty());
     }
 
     @Test
@@ -72,7 +75,7 @@ public class JdbcConfigSourceFactoryTest {
 
         Iterable<ConfigSource> it = factory.getConfigSources(context);
 
-        assertTrue(((Collection<?>) it).size() == 0);
+        assertTrue(((Collection<?>) it).isEmpty());
     }
 
 }


### PR DESCRIPTION
This is a prototype implementation of #49, by introducing  `quarkus.config.source.jdbc.cache` configuration which defaults to true to choose between in-memory or actively getting values from database