### PR TITLE
Add a direct dependency on jsoup and upgrade to Quarkus 2.10.0.Final

### DIFF
--- a/consul/deployment/pom.xml
+++ b/consul/deployment/pom.xml
@@ -31,6 +31,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 2.8.0.Final
+:quarkus-version: 2.10.0.Final
 :quarkus-config-extensions-version: 1.0.2
 :maven-version: 3.8.1+
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,9 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>2.9.0.Final</quarkus.version>
+        <quarkus.version>2.10.0.Final</quarkus.version>
         <assertj.version>3.22.0</assertj.version>
+        <jsoup.version>1.15.1</jsoup.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -37,7 +38,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
+            <dependency>
+                <groupId>org.jsoup</groupId>
+                <artifactId>jsoup</artifactId>
+                <version>${jsoup.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>


### PR DESCRIPTION
jsoup was removed in the current main branch of Quarkus, which causes the platform CI to fail.
This PR introduces a direct dependency on jsoup and upgrades the Quarkus version to latest final release which is 2.10.0.Final.