### PR TITLE
Adjust doc title

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: quarkus-config-extensions
-title: Quarkus Config Extensions
+title: Config Extensions
 version: dev
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
This will remove the  `Quarkus ` prefix in the documentation title