### PR TITLE
Make JdbcConfig runtime to not fail during the build when configuration is missing

### DIFF
--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigConfig.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigConfig.java
@@ -17,7 +17,7 @@ import io.smallrye.config.WithName;
  * The config itself is loaded using the ConfigSourceContext on the ConfigSourceFactory
  */
 @ConfigMapping(prefix = "quarkus.config.source.jdbc")
-@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
 public interface JdbcConfigConfig {
 
     /**

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSourceFactory.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigSourceFactory.java
@@ -1,7 +1,9 @@
 package io.quarkiverse.config.jdbc.runtime;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -9,13 +11,24 @@ import org.jboss.logging.Logger;
 
 import io.smallrye.config.ConfigSourceContext;
 import io.smallrye.config.ConfigSourceFactory;
+import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.common.MapBackedConfigSource;
 
-public class JdbcConfigSourceFactory implements ConfigSourceFactory.ConfigurableConfigSourceFactory<JdbcConfigConfig> {
+public class JdbcConfigSourceFactory implements ConfigSourceFactory {
     private static final Logger log = Logger.getLogger(JdbcConfigSourceFactory.class);
 
+    // TODO - Cannot use ConfigurableConfigSourceFactory, because profiles are not being propagated. Need a fix in SR Config
     @Override
-    public Iterable<ConfigSource> getConfigSources(final ConfigSourceContext context, final JdbcConfigConfig config) {
+    public Iterable<ConfigSource> getConfigSources(final ConfigSourceContext context) {
+        List<String> profiles = new ArrayList<>(context.getProfiles());
+        Collections.reverse(profiles);
+
+        JdbcConfigConfig config = new SmallRyeConfigBuilder()
+                .withSources(new ConfigSourceContext.ConfigSourceContextConfigSource(context))
+                .withProfiles(profiles)
+                .withMapping(JdbcConfigConfig.class)
+                .build().getConfigMapping(JdbcConfigConfig.class);
+
         if (!config.enabled()) {
             return Collections.emptyList();
         }


### PR DESCRIPTION
- Fixes #169