### PR TITLE
Make username/password optional and add driver property

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-jdbc-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-jdbc-config.adoc
@@ -41,7 +41,7 @@ a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.key]]`link:#quarkus-jdbc-con
 --
 Name of the column containing the key
 --|string 
-|`key`
+|`configuration_key`
 
 
 a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.value]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.value[quarkus.config.source.jdbc.value]`
@@ -50,7 +50,7 @@ a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.value]]`link:#quarkus-jdbc-c
 --
 Name of the column containing the value
 --|string 
-|`value`
+|`configuration_value`
 
 
 a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.username]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.username[quarkus.config.source.jdbc.username]`
@@ -78,6 +78,15 @@ a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.url]]`link:#quarkus-jdbc-con
 The datasource URL, if not defined the URL of the default datasource is used
 --|string 
 | value of `quarkus.datasource..jdbc.url`
+
+
+a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.driver]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.driver[quarkus.config.source.jdbc.driver]`
+
+[.description]
+--
+The datasource driver, if not defined the driver of the default datasource is used
+--|string
+| value of `quarkus.datasource..jdbc.driver`
 
 
 a| [[quarkus-jdbc-config_quarkus.config.source.jdbc.initial-size]]`link:#quarkus-jdbc-config_quarkus.config.source.jdbc.initial-size[quarkus.config.source.jdbc.initial-size]`

--- a/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigConfig.java
+++ b/jdbc/runtime/src/main/java/io/quarkiverse/config/jdbc/runtime/JdbcConfigConfig.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.config.jdbc.runtime;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -57,19 +58,25 @@ public interface JdbcConfigConfig {
      * The datasource username, if not defined the username of the default datasource is used
      */
     @WithDefault("${quarkus.datasource.username}")
-    String username();
+    Optional<String> username();
 
     /**
      * The datasource password, if not defined the password of the default datasource is used
      */
     @WithDefault("${quarkus.datasource.password}")
-    String password();
+    Optional<String> password();
 
     /**
      * The datasource URL, if not defined the URL of the default datasource is used
      */
     @WithDefault("${quarkus.datasource.jdbc.url}")
     String url();
+
+    /**
+     * The datasource driver, if not defined the driver of the default datasource is used
+     */
+    @WithDefault("${quarkus.datasource.jdbc.driver}")
+    Optional<String> driver();
 
     /**
      * The initial size of the pool. Usually you will want to set the initial size to match at least the


### PR DESCRIPTION
As we may not have both `username` and `password` set (for example when using Oracle Wallet, only the URL is set), I made them optional (otherwise it throws an exception if they are empty).

I also added the `driver` property that was missing. Not having it defined, for example for Oracle, will lead to runtime exceptions not finding the corresponding driver.

I updated the documentation accordingly and took the opportunity to update the default value of `key` and `value` fields as they had a different default value from what was documented.